### PR TITLE
Modified detections explicitly targeted towards macOS to not include cgroup field

### DIFF
--- a/detection/credentials/macos_keyboard_sniffer.sql
+++ b/detection/credentials/macos_keyboard_sniffer.sql
@@ -28,7 +28,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent

--- a/detection/credentials/unexpected-dev-opener-macos.sql
+++ b/detection/credentials/unexpected-dev-opener-macos.sql
@@ -32,7 +32,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent

--- a/detection/discovery/unexpected-netutil-calls-macos.sql
+++ b/detection/discovery/unexpected-netutil-calls-macos.sql
@@ -14,11 +14,9 @@ SELECT
   pe.cwd AS p0_cwd,
   pe.pid AS p0_pid,
   pe.euid AS p0_euid,
-  p.cgroup_path AS p0_cgroup,
   s.authority AS p0_authority,
   -- Parent
-  pe.parent AS p1_pid,
-  p1.cgroup_path AS p1_cgroup,
+  pe.parent AS p1_pid,  
   TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
   COALESCE(p1.path, pe1.path) AS p1_path,
   COALESCE(p_hash1.sha256, pe_hash1.sha256) AS p1_hash,
@@ -26,7 +24,6 @@ SELECT
   pe_sig1.authority AS p1_authority,
   -- Grandparent
   COALESCE(p1.parent, pe1.parent) AS p2_pid,
-  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
   TRIM(
     COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
   ) AS p2_cmd,

--- a/detection/discovery/unexpected-pcap-user-macos.sql
+++ b/detection/discovery/unexpected-pcap-user-macos.sql
@@ -14,7 +14,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent

--- a/detection/evasion/parent-missing-from-disk-macos.sql
+++ b/detection/evasion/parent-missing-from-disk-macos.sql
@@ -23,7 +23,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent

--- a/detection/execution/exotic-command-events-macos.sql
+++ b/detection/execution/exotic-command-events-macos.sql
@@ -16,11 +16,9 @@ SELECT -- Child
   pe.cwd AS p0_cwd,
   pe.pid AS p0_pid,
   pe.euid AS p0_euid,
-  p.cgroup_path AS p0_cgroup,
   s.authority AS p0_authority,
   -- Parent
   pe.parent AS p1_pid,
-  p1.cgroup_path AS p1_cgroup,
   TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
   COALESCE(p1.path, pe1.path) AS p1_path,
   COALESCE(p_hash1.sha256, pe_hash1.sha256) AS p1_hash,
@@ -28,7 +26,6 @@ SELECT -- Child
   pe_sig1.authority AS p1_authority,
   -- Grandparent
   COALESCE(p1.parent, pe1.parent) AS p2_pid,
-  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
   TRIM(
     COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
   ) AS p2_cmd,

--- a/detection/execution/exotic-commands-macos.sql
+++ b/detection/execution/exotic-commands-macos.sql
@@ -14,7 +14,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent

--- a/detection/execution/recently-created-executables-macos.sql
+++ b/detection/execution/recently-created-executables-macos.sql
@@ -18,7 +18,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent

--- a/detection/execution/unexpected-execdir-events-macos.sql
+++ b/detection/execution/unexpected-execdir-events-macos.sql
@@ -31,17 +31,14 @@ SELECT
   pe.cwd AS p0_cwd,
   pe.pid AS p0_pid,
   pe.euid AS p0_euid,
-  p.cgroup_path AS p0_cgroup,
   -- Parent
   pe.parent AS p1_pid,
-  p1.cgroup_path AS p1_cgroup,
   TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
   COALESCE(p1.path, pe1.path) AS p1_path,
   COALESCE(p_hash1.sha256, pe_hash1.sha256) AS p1_hash,
   REGEX_MATCH (COALESCE(p1.path, pe1.path), '.*/(.*)', 1) AS p1_name,
   -- Grandparent
   COALESCE(p1.parent, pe1.parent) AS p2_pid,
-  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
   TRIM(
     COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
   ) AS p2_cmd,

--- a/detection/execution/unexpected-root-signer-macos.sql
+++ b/detection/execution/unexpected-root-signer-macos.sql
@@ -15,17 +15,14 @@ SELECT
   pe.cwd AS p0_cwd,
   pe.pid AS p0_pid,
   pe.euid AS p0_euid,
-  p.cgroup_path AS p0_cgroup,
   -- Parent
   pe.parent AS p1_pid,
-  p1.cgroup_path AS p1_cgroup,
   TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
   COALESCE(p1.path, pe1.path) AS p1_path,
   COALESCE(p_hash1.sha256, pe_hash1.sha256) AS p1_hash,
   REGEX_MATCH (COALESCE(p1.path, pe1.path), '.*/(.*)', 1) AS p1_name,
   -- Grandparent
   COALESCE(p1.parent, pe1.parent) AS p2_pid,
-  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
   TRIM(
     COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
   ) AS p2_cmd,

--- a/detection/execution/unexpected-security-framework-program-macos.sql
+++ b/detection/execution/unexpected-security-framework-program-macos.sql
@@ -21,7 +21,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent

--- a/detection/execution/unexpected-sysutils-macos.sql
+++ b/detection/execution/unexpected-sysutils-macos.sql
@@ -16,7 +16,6 @@ SELECT
   s.authority AS p0_authority,
   -- Parent
   pe.parent AS p1_pid,
-  p1.cgroup_path AS p1_cgroup,
   TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
   COALESCE(p1.path, pe1.path) AS p1_path,
   COALESCE(p_hash1.sha256, pe_hash1.sha256) AS p1_hash,
@@ -24,7 +23,6 @@ SELECT
   pe_sig1.authority AS p1_authority,
   -- Grandparent
   COALESCE(p1.parent, pe1.parent) AS p2_pid,
-  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
   TRIM(
     COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
   ) AS p2_cmd,

--- a/detection/execution/unexpected-xattr-calls-macos.sql
+++ b/detection/execution/unexpected-xattr-calls-macos.sql
@@ -17,7 +17,6 @@ SELECT
   s.authority AS p0_authority,
   -- Parent
   pe.parent AS p1_pid,
-  p1.cgroup_path AS p1_cgroup,
   TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
   COALESCE(p1.path, pe1.path) AS p1_path,
   COALESCE(p_hash1.sha256, pe_hash1.sha256) AS p1_hash,
@@ -25,7 +24,6 @@ SELECT
   pe_sig1.authority AS p1_authority,
   -- Grandparent
   COALESCE(p1.parent, pe1.parent) AS p2_pid,
-  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
   TRIM(
     COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
   ) AS p2_cmd,

--- a/detection/privesc/unexpected-elevated-children-events_macos.sql
+++ b/detection/privesc/unexpected-elevated-children-events_macos.sql
@@ -18,11 +18,9 @@ SELECT
   pe.cwd AS p0_cwd,
   pe.pid AS p0_pid,
   pe.euid AS p0_euid,
-  p.cgroup_path AS p0_cgroup,
   s.authority AS p0_authority,
   -- Parent
   pe.parent AS p1_pid,
-  p1.cgroup_path AS p1_cgroup,
   TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
   COALESCE(p1.path, pe1.path) AS p1_path,
   COALESCE(p1.euid, pe1.euid) AS p1_euid,
@@ -31,7 +29,6 @@ SELECT
   pe_sig1.authority AS p1_authority,
   -- Grandparent
   COALESCE(p1.parent, pe1.parent) AS p2_pid,
-  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
   TRIM(
     COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
   ) AS p2_cmd,

--- a/detection/privesc/unexpected-privilege-escalation_macos.sql
+++ b/detection/privesc/unexpected-privilege-escalation_macos.sql
@@ -17,7 +17,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent

--- a/fragments/process_event_parents_macos.sql
+++ b/fragments/process_event_parents_macos.sql
@@ -9,17 +9,14 @@ SELECT
   pe.cwd AS p0_cwd,
   pe.pid AS p0_pid,
   pe.euid AS p0_euid,
-  p.cgroup_path AS p0_cgroup,
   -- Parent
   pe.parent AS p1_pid,
-  p1.cgroup_path AS p1_cgroup,
   TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
   COALESCE(p1.path, pe1.path) AS p1_path,
   COALESCE(p_hash1.sha256, pe_hash1.sha256) AS p1_hash,
   REGEX_MATCH (COALESCE(p1.path, pe1.path), '.*/(.*)', 1) AS p1_name,
   -- Grandparent
   COALESCE(p1.parent, pe1.parent) AS p2_pid,
-  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
   TRIM(
     COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
   ) AS p2_cmd,


### PR DESCRIPTION
As far as I am aware, cgroups are a linux only [feature](https://en.wikipedia.org/wiki/Cgroups)

Checking with the osquery schema for the `processes` [table](https://github.com/osquery/osquery/blob/master/specs/processes.table) , we can see that the `cgroup_path` field is billed as a Linux only field:
```
extended_schema(LINUX, [
    Column("cgroup_path", TEXT, "The full hierarchical path of the process's control group")
```

Testing this on my local machine through the `osqueryi` shell, and also as part of the schedule with `osqueryd` has produced errors with execution as the `cgroup_path` field is not recognised on macOS.

As a result I tried to remove all the references to `cgroup_path`, as from my understanding of the queries that used them, they are mostly used as enrichment fields.






