### PR TITLE
Remove cgroup from macOS reference fragment, add fragments README

### DIFF
--- a/fragments/README.md
+++ b/fragments/README.md
@@ -1,0 +1,2 @@
+These are reference query fragments that are meant to be shared across queries.
+

--- a/fragments/process_parents_macos.sql
+++ b/fragments/process_parents_macos.sql
@@ -7,7 +7,6 @@ SELECT
   p0.name AS p0_name,
   p0.cmdline AS p0_cmd,
   p0.cwd AS p0_cwd,
-  p0.cgroup_path AS p0_cgroup,
   p0.euid AS p0_euid,
   p0_hash.sha256 AS p0_sha256,
   -- Parent


### PR DESCRIPTION
Fixes the last errant cgroup inclusion, and fixes #161 