### PR TITLE
macos sniffers: back out osquery change until we understand it better

### DIFF
--- a/detection/credentials/macos_keyboard_sniffer.sql
+++ b/detection/credentials/macos_keyboard_sniffer.sql
@@ -57,10 +57,8 @@ FROM
   LEFT JOIN hash p2_hash ON p2.path = p2_hash.path
 WHERE
   et.event_tapped IN ('EventKeyDown', 'EventKeyUp')
-  AND s.authority != 'Software Signing'
-  -- Popular programs that sniff keyboard events, but do not appear to be malware.
+  AND s.authority != 'Software Signing' -- Popular programs that sniff keyboard events, but do not appear to be malware.
   AND NOT exception_key IN (
-    'TextExpander,com.smileonmymac.textexpander,Developer ID Application: SmileOnMyMac, LLC (7PKJ6G4DXL)',
     'BetterTouchTool,com.hegenberg.BetterTouchTool,Developer ID Application: folivora.AI GmbH (DAFVSXZ82P)',
     'Contexts,com.contextsformac.Contexts,Developer ID Application: Usman Khalid (RZ7E748ZSC)',
     'Hyperkey,com.knollsoft.Hyperkey,Developer ID Application: Ryan Hanson (XSYZ3E4B7D)',
@@ -69,7 +67,7 @@ WHERE
     'logioptionsplus_agent,com.logi.cp-dev-mgr,Developer ID Application: Logitech Inc. (QED4VVPZWA)',
     'MonitorControl,me.guillaumeb.MonitorControl,Developer ID Application: Joni Van Roost (CYC8C8R4K9)',
     'skhd,skhd,',
-    'osqueryd,io.osquery.agent,Developer ID Application: OSQUERY A Series of LF Projects, LLC (3522FA9PXF)'
+    'TextExpander,com.smileonmymac.textexpander,Developer ID Application: SmileOnMyMac, LLC (7PKJ6G4DXL)'
   )
 GROUP BY
   p0.path


### PR DESCRIPTION
Related to #185 

I'm temporarily backing this change out until there is more evidence as to why osquery might be sniffing for keystrokes. 

Also run `make reformat-updates` and `sort -u` on exceptions.