### PR TITLE
unexpected-chmod-exec: Split and Linux/macOS queries

### DIFF
--- a/detection/execution/exotic-command-events-macos.sql
+++ b/detection/execution/exotic-command-events-macos.sql
@@ -103,7 +103,7 @@ WHERE
     OR p0_name LIKE '%attack%' -- Unusual behaviors
     OR p0_cmd LIKE '%powershell%'
     OR p0_cmd LIKE '%chattr -i%'
-    OR p0.cmdline LIKE '%dd if=/dev/%'
+    OR p0_cmd LIKE '%dd if=/dev/%'
     OR p0_cmd LIKE '%cat /dev/null >%'
     OR p0_cmd LIKE '%truncate -s0 %'
     OR p0_cmd LIKE '%touch%acmr%'

--- a/detection/execution/exotic-commands-macos.sql
+++ b/detection/execution/exotic-commands-macos.sql
@@ -94,12 +94,12 @@ WHERE
       OR p.cmdline LIKE '%dd if=/dev/%'
   )
   AND NOT (
-    p0.cmdline LIKE '%UserKnownHostsFile=/dev/null%'
+    p0_cmd LIKE '%UserKnownHostsFile=/dev/null%'
     AND p1.name == 'limactl'
   )
   AND NOT (
-    p0.cmdline LIKE '%sh -i'
-    AND p1.cmdline LIKE '%pipenv shell'
+    p0_cmd LIKE '%sh -i'
+    AND p1_cmd LIKE '%pipenv shell'
   )
   AND NOT p0_cmd IN ('pkill -f Jabra Direct')
 GROUP BY

--- a/detection/execution/unexpected-chmod-exec-event-linux.sql
+++ b/detection/execution/unexpected-chmod-exec-event-linux.sql
@@ -1,0 +1,95 @@
+-- Things that call chmod to set executable permissions
+--
+-- references:
+--   * https://www.microsoft.com/en-us/security/blog/2022/05/19/rise-in-xorddos-a-deeper-look-at-the-stealthy-ddos-malware-targeting-linux-devices/
+--
+-- false positives:
+--   * loads of them
+--
+-- tags: transient process events
+-- platform: linux
+-- interval: 180
+SELECT
+  IFNULL(REGEX_MATCH(TRIM(pe.cmdline), '.* (/.*)', 1), CONCAT(pe.cwd, '/', REGEX_MATCH(TRIM(pe.cmdline), '.* (.*)', 1))) AS f_path,
+  f.mode AS f_mode,
+  f.type AS f_type,
+  hash.sha256 AS f_hash,
+  magic.data AS f_magic,
+  -- Child
+  pe.path AS p0_path,
+  TRIM(pe.cmdline) AS p0_cmd,
+  pe.cwd AS p0_cwd,
+  pe.pid AS p0_pid,
+  p.cgroup_path AS p0_cgroup,
+  -- Parent
+  pe.parent AS p1_pid,
+  p1.cgroup_path AS p1_cgroup,
+  TRIM(COALESCE(p1.cmdline, pe1.cmdline)) AS p1_cmd,
+  COALESCE(p1.path, pe1.path) AS p1_path,
+  COALESCE(p_hash1.sha256, pe_hash1.sha256) AS p1_hash,
+  REGEX_MATCH (COALESCE(p1.path, pe1.path), '.*/(.*)', 1) AS p1_name,
+  -- Grandparent
+  COALESCE(p1.parent, pe1.parent) AS p2_pid,
+  COALESCE(p1_p2.cgroup_path, pe1_p2.cgroup_path) AS p2_cgroup,
+  TRIM(
+    COALESCE(p1_p2.cmdline, pe1_p2.cmdline, pe1_pe2.cmdline)
+  ) AS p2_cmd,
+  COALESCE(p1_p2.path, pe1_p2.path, pe1_pe2.path) AS p2_path,
+  COALESCE(
+    p1_p2_hash.path,
+    pe1_p2_hash.path,
+    pe1_pe2_hash.path
+  ) AS p2_hash,
+  REGEX_MATCH (
+    COALESCE(p1_p2.path, pe1_p2.path, pe1_pe2.path),
+    '.*/(.*)',
+    1
+  ) AS p2_name,
+  -- Exception key
+  REGEX_MATCH (pe.path, '.*/(.*)', 1) || ',' || MIN(pe.euid, 500) || ',' || REGEX_MATCH (COALESCE(p1.path, pe1.path), '.*/(.*)', 1) || ',' || REGEX_MATCH (
+    COALESCE(p1_p2.path, pe1_p2.path, pe1_pe2.path),
+    '.*/(.*)',
+    1
+  ) AS exception_key
+FROM
+  process_events pe
+  LEFT JOIN processes p ON pe.pid = p.pid
+  -- Wow, you can do that?
+  LEFT JOIN file f ON IFNULL(REGEX_MATCH(TRIM(pe.cmdline), '.* (/.*)', 1), CONCAT(pe.cwd, '/', REGEX_MATCH(TRIM(pe.cmdline), '.* (.*)', 1))) = f.path
+  LEFT JOIN hash ON f.path = hash.path
+  LEFT JOIN magic ON f.path = magic.path
+  -- Parents (via two paths)
+  LEFT JOIN processes p1 ON pe.parent = p1.pid
+  LEFT JOIN hash p_hash1 ON p1.path = p_hash1.path
+  LEFT JOIN process_events pe1 ON pe.parent = pe1.pid
+  AND pe1.cmdline != ''
+  LEFT JOIN hash pe_hash1 ON pe1.path = pe_hash1.path
+  -- Grandparents (via 3 paths)
+  LEFT JOIN processes p1_p2 ON p1.parent = p1_p2.pid -- Current grandparent via parent processes
+  LEFT JOIN processes pe1_p2 ON pe1.parent = pe1_p2.pid -- Current grandparent via parent events
+  LEFT JOIN process_events pe1_pe2 ON pe1.parent = pe1_p2.pid
+  AND pe1_pe2.cmdline != '' -- Past grandparent via parent events
+  LEFT JOIN hash p1_p2_hash ON p1_p2.path = p1_p2_hash.path
+  LEFT JOIN hash pe1_p2_hash ON pe1_p2.path = pe1_p2_hash.path
+  LEFT JOIN hash pe1_pe2_hash ON pe1_pe2.path = pe1_pe2_hash.path
+WHERE
+  pe.pid IN (
+    SELECT DISTINCT pid FROM process_events WHERE
+    time > (strftime('%s', 'now') -180)
+    AND pe.syscall = "execve"
+    AND (
+      cmdline LIKE '%chmod% 7%'
+      OR cmdline LIKE '%chmod% +rwx%'
+      OR cmdline LIKE '%chmod% +x%'
+      OR cmdline LIKE '%chmod% u+x%'
+      OR cmdline LIKE '%chmod% a+x%'
+    )
+    AND cmdline NOT LIKE 'chmod 777 /app/%'
+    AND cmdline NOT LIKE 'chmod 700 /tmp/apt-key-gpghome.%'
+    AND cmdline NOT LIKE 'chmod 700 /home/%/snap/%/%/.config'
+  )
+  AND pe.syscall = "execve"
+  AND f.type != 'directory'
+  AND p0.cgroup_path NOT LIKE '/system.slice/docker-%'
+  AND p0.cgroup_path NOT LIKE '/user.slice/user-1000.slice/user@1000.service/user.slice/nerdctl-%'
+GROUP BY p0_pid

--- a/detection/execution/unexpected-chmod-exec-event-linux.sql
+++ b/detection/execution/unexpected-chmod-exec-event-linux.sql
@@ -10,7 +10,14 @@
 -- platform: linux
 -- interval: 180
 SELECT
-  IFNULL(REGEX_MATCH(TRIM(pe.cmdline), '.* (/.*)', 1), CONCAT(pe.cwd, '/', REGEX_MATCH(TRIM(pe.cmdline), '.* (.*)', 1))) AS f_path,
+  IFNULL(
+    REGEX_MATCH (TRIM(pe.cmdline), '.* (/.*)', 1),
+    CONCAT (
+      pe.cwd,
+      '/',
+      REGEX_MATCH (TRIM(pe.cmdline), '.* (.*)', 1)
+    )
+  ) AS f_path,
   f.mode AS f_mode,
   f.type AS f_type,
   hash.sha256 AS f_hash,
@@ -20,7 +27,6 @@ SELECT
   TRIM(pe.cmdline) AS p0_cmd,
   pe.cwd AS p0_cwd,
   pe.pid AS p0_pid,
-  p.cgroup_path AS p0_cgroup,
   -- Parent
   pe.parent AS p1_pid,
   p1.cgroup_path AS p1_cgroup,
@@ -55,7 +61,14 @@ FROM
   process_events pe
   LEFT JOIN processes p ON pe.pid = p.pid
   -- Wow, you can do that?
-  LEFT JOIN file f ON IFNULL(REGEX_MATCH(TRIM(pe.cmdline), '.* (/.*)', 1), CONCAT(pe.cwd, '/', REGEX_MATCH(TRIM(pe.cmdline), '.* (.*)', 1))) = f.path
+  LEFT JOIN file f ON IFNULL(
+    REGEX_MATCH (TRIM(pe.cmdline), '.* (/.*)', 1),
+    CONCAT (
+      pe.cwd,
+      '/',
+      REGEX_MATCH (TRIM(pe.cmdline), '.* (.*)', 1)
+    )
+  ) = f.path
   LEFT JOIN hash ON f.path = hash.path
   LEFT JOIN magic ON f.path = magic.path
   -- Parents (via two paths)
@@ -74,22 +87,29 @@ FROM
   LEFT JOIN hash pe1_pe2_hash ON pe1_pe2.path = pe1_pe2_hash.path
 WHERE
   pe.pid IN (
-    SELECT DISTINCT pid FROM process_events WHERE
-    time > (strftime('%s', 'now') -180)
-    AND pe.syscall = "execve"
-    AND (
-      cmdline LIKE '%chmod% 7%'
-      OR cmdline LIKE '%chmod% +rwx%'
-      OR cmdline LIKE '%chmod% +x%'
-      OR cmdline LIKE '%chmod% u+x%'
-      OR cmdline LIKE '%chmod% a+x%'
-    )
-    AND cmdline NOT LIKE 'chmod 777 /app/%'
-    AND cmdline NOT LIKE 'chmod 700 /tmp/apt-key-gpghome.%'
-    AND cmdline NOT LIKE 'chmod 700 /home/%/snap/%/%/.config'
+    SELECT DISTINCT
+      pid
+    FROM
+      process_events
+    WHERE
+      time > (strftime('%s', 'now') -180)
+      AND pe.syscall = "execve"
+      AND (
+        cmdline LIKE '%chmod% 7%'
+        OR cmdline LIKE '%chmod% +rwx%'
+        OR cmdline LIKE '%chmod% +x%'
+        OR cmdline LIKE '%chmod% u+x%'
+        OR cmdline LIKE '%chmod% a+x%'
+      )
+      AND cmdline NOT LIKE 'chmod 777 /app/%'
+      AND cmdline NOT LIKE 'chmod 700 /tmp/apt-key-gpghome.%'
+      AND cmdline NOT LIKE 'chmod 700 /home/%/snap/%/%/.config'
   )
   AND pe.syscall = "execve"
   AND f.type != 'directory'
-  AND p0.cgroup_path NOT LIKE '/system.slice/docker-%'
-  AND p0.cgroup_path NOT LIKE '/user.slice/user-1000.slice/user@1000.service/user.slice/nerdctl-%'
-GROUP BY p0_pid
+  AND p1_cgroup NOT LIKE '/system.slice/docker-%'
+  AND p1_cgroup NOT LIKE '/user.slice/user-1000.slice/user@1000.service/user.slice/nerdctl-%'
+  AND p2_cgroup NOT LIKE '/system.slice/docker-%'
+  AND p2_cgroup NOT LIKE '/user.slice/user-1000.slice/user@1000.service/user.slice/nerdctl-%'
+GROUP BY
+  p0_pid

--- a/detection/execution/unexpected-chmod-exec-event-macos.sql
+++ b/detection/execution/unexpected-chmod-exec-event-macos.sql
@@ -7,7 +7,7 @@
 --   * loads of them
 --
 -- tags: transient process events
--- platform: posix
+-- platform: darwin
 -- interval: 180
 SELECT
   IFNULL(REGEX_MATCH(TRIM(pe.cmdline), '.* (/.*)', 1), CONCAT(pe.cwd, '/', REGEX_MATCH(TRIM(pe.cmdline), '.* (.*)', 1))) AS f_path,
@@ -76,6 +76,8 @@ WHERE
   pe.pid IN (
     SELECT DISTINCT pid FROM process_events WHERE
     time > (strftime('%s', 'now') -180)
+    AND pe.status = 0
+    AND pe.parent > 0
     AND (
       cmdline LIKE '%chmod% 7%'
       OR cmdline LIKE '%chmod% +rwx%'
@@ -83,9 +85,6 @@ WHERE
       OR cmdline LIKE '%chmod% u+x%'
       OR cmdline LIKE '%chmod% a+x%'
     )
-    AND cmdline NOT LIKE 'chmod 777 /app/%'
-    AND cmdline NOT LIKE 'chmod 700 /tmp/apt-key-gpghome.%'
-    AND cmdline NOT LIKE 'chmod 700 /home/%/snap/%/%/.config'
     AND cmdline != 'chmod 0777 /Users/Shared/logitune'
   )
   AND f.type != 'directory'


### PR DESCRIPTION
They use subtly different fields to assess a truly functional execve() call.