### PR TITLE
Ignore taint code 4096 (out-of-tree driver)

### DIFF
--- a/detection/evasion/unusually-tainted-kernel-linux.sql
+++ b/detection/evasion/unusually-tainted-kernel-linux.sql
@@ -37,10 +37,11 @@ FROM
     ORDER BY
       km.name ASC
   )
+  -- 4096 is a signed, out of tree, open source driver
   -- 4097 is a signed, out of tree, proprietary driver
   -- 512 is a kernel warning
 WHERE
-  taint NOT IN (0, 512, 4097)
+  taint NOT IN (0, 512, 4096, 4097)
   AND NOT (
     (
       -- 12289 is an unsigned, out of tree, proprietary


### PR DESCRIPTION
If folks go to the trouble of signing their out-of-tree drivers, it's probably not a random rootkit. This was seen with v4l2loopback.ko

/cc @xnox 