### PR TITLE
Add exceptions for Docker's kubectl, ngrok, SAFEQ, and Zed

### DIFF
--- a/detection/c2/unexpected-https-macos.sql
+++ b/detection/c2/unexpected-https-macos.sql
@@ -140,7 +140,9 @@ WHERE
     '500,snyk-ls_darwin_arm64,snyk-ls_darwin_arm64,,a.out',
     '500,syncthing,syncthing,,syncthing',
     '500,trunk,trunk,Developer ID Application: Trunk Technologies, Inc. (LDR5F9BL92),trunk-cli',
-    '500,zed,zed,Developer ID Application: Zed Industries, Inc. (MQ55VZLNZQ),dev.zed.Zed'
+    '500,zed,zed,Developer ID Application: Zed Industries, Inc. (MQ55VZLNZQ),dev.zed.Zed',
+    '500,ngrok,ngrok,Developer ID Application: ngrok LLC (TEX8MHRDQ9),a.out',
+    '500,kubectl,kubectl,Developer ID Application: Docker Inc (9BNSXJN65R),kubectl'
   )
   AND NOT alt_exception_key IN (
     '0,velociraptor,velociraptor,0u,0g',

--- a/detection/c2/unexpected-talkers-macos.sql
+++ b/detection/c2/unexpected-talkers-macos.sql
@@ -194,7 +194,9 @@ WHERE pos.protocol > 0
     '500,6,993,thunderbird,thunderbird,Developer ID Application: Mozilla Corporation (43AQ936H96),org.mozilla.thunderbird',
     '500,6,995,KakaoTalk,KakaoTalk,Apple Mac OS Application Signing,com.kakao.KakaoTalkMac',
     '0,6,853,at.obdev.littlesnitch.networkextension,at.obdev.littlesnitch.networkextension,0u,0g',
-    '500,6,21,Cyberduck,Cyberduck,Developer ID Application: David Kocher (G69SCX94XU),ch.sudo.cyberduck'
+    '500,6,21,Cyberduck,Cyberduck,Developer ID Application: David Kocher (G69SCX94XU),ch.sudo.cyberduck',
+    '500,6,7881,zed,zed,Developer ID Application: Zed Industries, Inc. (MQ55VZLNZQ),dev.zed.Zed',
+    '0,6,7300,safeqclientcore,safeqclientcore,Developer ID Application: Y Soft Corporation, a.s. (3CPED8WGS9),safeqclientcore'
   ) -- Useful for unsigned binaries
   AND NOT alt_exception_key IN (
     '0,6,80,tailscaled,tailscaled,500u,80g',


### PR DESCRIPTION
Another round of exceptions for Docker's kubectl, ngrok, SAFEQ, and Zed.