### PR TITLE
mark https-linux extra, minor query tuning

### DIFF
--- a/detection/c2/unexpected-dns-traffic-events.sql
+++ b/detection/c2/unexpected-dns-traffic-events.sql
@@ -67,7 +67,8 @@ WHERE
     '75.75.75.75', -- Comcast
     '75.75.76.76', -- Comcast
     '68.105.28.13', -- Cox
-    '80.248.7.1' -- 21st Century (NG)
+    '80.248.7.1', -- 21st Century (NG)
+    '34.160.111.32' -- wolfi.dev
   )
   -- Exceptions that specifically talk to one server
   AND exception_key NOT IN (
@@ -125,7 +126,7 @@ WHERE
     'systemd-resolved',
     'WhatsApp'
   )
-  AND p.name NOT IN ('Jabra Direct Helper')
+  AND p.name NOT IN ('Jabra Direct Helper', 'terraform-provi')
   -- Chromium/Electron apps seem to send stray packets out like nobodies business
   AND p.path NOT LIKE '%/%.app/Contents/MacOS/% Helper'
   -- Workaround for the GROUP_CONCAT subselect adding a blank ent

--- a/detection/c2/unexpected-https-linux.sql
+++ b/detection/c2/unexpected-https-linux.sql
@@ -6,7 +6,7 @@
 -- references:
 --   * https://attack.mitre.org/techniques/T1071/ (C&C, Application Layer Protocol)
 --
--- tags: transient state net often
+-- tags: transient state net often extra
 -- platform: linux
 SELECT
   s.remote_address,

--- a/detection/evasion/hidden-executable.sql
+++ b/detection/evasion/hidden-executable.sql
@@ -70,6 +70,7 @@ WHERE
   AND NOT f.directory LIKE '%/node_modules/.bin/%'
   AND NOT f.directory LIKE '%/.nvm/versions/%/bin'
   AND NOT f.directory LIKE '%/.pnpm/%'
+  AND NOT f.directory LIKE '/var/home/linuxbrew/.linuxbrew/%'
   AND NOT f.directory LIKE '%/.cache/selenium/chromedriver/%'
   AND NOT f.directory LIKE '%/.provisio/bin/%'
   AND NOT f.directory LIKE '%/.rustup/%'

--- a/detection/evasion/unexpected-process-extension-linux.sql
+++ b/detection/evasion/unexpected-process-extension-linux.sql
@@ -79,6 +79,7 @@ WHERE
     'nox',
     'basic',
     'real',
+    'test',
     'AppImage',
     'ext'
   )

--- a/detection/evasion/unusual-executable-name-linux.sql
+++ b/detection/evasion/unusual-executable-name-linux.sql
@@ -84,7 +84,7 @@ WHERE
       REGEX_MATCH (pname, "(\W)$", 1) != ""
       AND pname NOT LIKE "%)"
     )
-    AND pext NOT IN ("", "gui", "cli", "us", "node", "com")
+    AND pext NOT IN ("", "gui", "cli", "us", "node", "com", "test")
   )
   AND NOT pname LIKE '.%-wrapped'
   AND NOT pname LIKE '__debug_bin%'

--- a/detection/execution/recently-created-executables-long-lived-linux.sql
+++ b/detection/execution/recently-created-executables-long-lived-linux.sql
@@ -45,7 +45,7 @@ WHERE
   p0.start_time > 0
   AND f.ctime > 0
   AND p0.start_time > (strftime('%s', 'now') - 43200)
-  AND (p0.start_time - MAX(f.ctime, f.btime)) < 1200
+  AND (p0.start_time - MAX(f.ctime, f.btime)) < 10800
   AND p0.start_time >= MAX(f.ctime, f.ctime)
   AND NOT f.directory IN ('/usr/lib/firefox', '/usr/local/kolide-k2/bin') -- Typically daemons or long-running desktop apps
   -- These are binaries that are known to get updated and subsequently executed

--- a/detection/execution/recently-created-executables-long-lived-macos.sql
+++ b/detection/execution/recently-created-executables-long-lived-macos.sql
@@ -78,7 +78,7 @@ WHERE
       AND NOT path LIKE '/usr/local/kolide-k2/bin/%'
       AND NOT path LIKE '%/cloud_sql_proxy'
   )
-  AND (p0.start_time - MAX(f.ctime, f.btime)) < 1200
+  AND (p0.start_time - MAX(f.ctime, f.btime)) < 10800
   AND f.ctime > 0
   AND NOT (
     p0.euid > 499

--- a/detection/execution/tiny-executable-events.sql
+++ b/detection/execution/tiny-executable-events.sql
@@ -45,9 +45,9 @@ WHERE
     '/sbin/ldconfig',
     '/usr/sbin/ldconfig',
     '/usr/bin/c_rehash',
-    '/home/smoser/bin/firefox',
     '/usr/sbin/update-ca-certificates'
   )
+  AND NOT p.path LIKE '%/bin/firefox'
   AND NOT (
     p.path LIKE '/Users/%'
     AND magic.data LIKE 'POSIX shell script%'

--- a/detection/exfil/high_disk_bytes_read.sql
+++ b/detection/exfil/high_disk_bytes_read.sql
@@ -50,10 +50,12 @@ WHERE
   bytes_read_rate > 2500000
   AND age > 180
   AND p0.path NOT LIKE '/Applications/%.app/Contents/%'
-  AND p0.path NOT LIKE '/System/Library/%'
-  AND p0.path NOT LIKE '/System/Applications/%'
-  AND p0.path NOT LIKE '/Library/Apple/System/Library/%'
+  AND p0.path NOT LIKE '%/bin/%'
+  AND p0.path NOT LIKE '/usr/%'
   AND p0.path NOT LIKE '/home/%/.local/share/Steam/steamapps/%'
+  AND p0.path NOT LIKE '/Library/Apple/System/Library/%'
+  AND p0.path NOT LIKE '/System/Applications/%'
+  AND p0.path NOT LIKE '/System/Library/%'
   AND p0.name NOT IN (
     'BDLDaemon',
     'Disk Inventory X',
@@ -158,36 +160,7 @@ WHERE
     '/Library/Application Support/Adobe/Adobe Desktop Common/HDBox/Setup',
     '/Library/Elastic/Endpoint/elastic-endpoint',
     '/System/Volumes/Preboot/Cryptexes/App/System/Applications/Safari.app/Contents/XPCServices/com.apple.Safari.BrowserDataImportingService.xpc/Contents/MacOS/com.apple.Safari.BrowserDataImportingService',
-    '/System/Volumes/Preboot/Cryptexes/Incoming/OS/System/Library/Frameworks/WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.WebContent.xpc/Contents/MacOS/com.apple.WebKit.WebContent',
-    '/usr/bin/apt',
-    '/usr/bin/darktable',
-    '/usr/bin/dockerd',
-    '/usr/bin/gnome-shell',
-    '/usr/bin/gnome-software',
-    '/usr/bin/rsync',
-    '/usr/bin/teskdisk',
-    '/usr/bin/topgrade',
-    '/usr/bin/udevadm',
-    '/usr/bin/update-notifier',
-    '/usr/lib64/electron/electron',
-    '/usr/libexec/aned',
-    '/usr/libexec/biomesyncd',
-    '/usr/libexec/coreduetd',
-    '/usr/libexec/diskimagesiod',
-    '/usr/libexec/diskmanagementd',
-    '/usr/libexec/flatpak-system-helper',
-    '/usr/libexec/logd',
-    '/usr/libexec/logd_helper',
-    '/usr/libexec/packagekitd',
-    '/usr/libexec/PerfPowerServices',
-    '/usr/libexec/signpost_reporter',
-    '/usr/libexec/snapd/snapd',
-    '/usr/libexec/syspolicyd',
-    '/usr/libexec/tracker-extract-3',
-    '/usr/libexec/tracker-miner-fs-3',
-    '/usr/lib/systemd/systemd',
-    '/usr/sbin/spindump',
-    '/usr/sbin/systemstats'
+    '/System/Volumes/Preboot/Cryptexes/Incoming/OS/System/Library/Frameworks/WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.WebContent.xpc/Contents/MacOS/com.apple.WebKit.WebContent'
   )
   AND NOT p0.path LIKE '/Library/SystemExtensions/%/io.kandji.KandjiAgent.ESF-Extension.systemextension/Contents/MacOS/io.kandji.KandjiAgent.ESF-Extension'
   AND NOT p0.path LIKE '/Users/%/Library/Application Support/Google/GoogleUpdater/%/GoogleUpdater.app/Contents/MacOS/GoogleUpdater'

--- a/detection/initial_access/unexpected-shell-parents.sql
+++ b/detection/initial_access/unexpected-shell-parents.sql
@@ -7,7 +7,7 @@
 --   * https://attack.mitre.org/techniques/T1059/ (Command and Scripting Interpreter)
 --   * https://attack.mitre.org/techniques/T1204/002/ (User Execution: Malicious File)
 --
--- tags: process events
+-- tags: process events extra
 -- interval: 60
 -- platform: posix
 SELECT
@@ -186,6 +186,7 @@ WHERE
     'zellij',
     'zsh'
   )
+  AND p1_path NOT LIKE '/Applications/%.app/Contents/MacOS/%'
   AND p1_path NOT IN (
     '/Applications/Docker.app/Contents/MacOS/Docker',
     '/Applications/Docker.app/Contents/MacOS/install',

--- a/detection/persistence/suspicious-systemd-unit.sql
+++ b/detection/persistence/suspicious-systemd-unit.sql
@@ -8,7 +8,7 @@
 -- false positives:
 --   * home-made systemd files
 --
--- tags: persistent filesystem systemd extra
+-- tags: persistent filesystem systemd
 -- platform: linux
 SELECT
   file.path,
@@ -117,6 +117,7 @@ rule systemd_small_multiuser_no_comments_or_documentation : high {
     $not_dbus = "Type=dbus"
     $not_oneshot = "Type=oneshot"
     $not_lima = "Description=lima-guestagent"
+    $not_bluefin = "projectbluefin.io"
   condition:
     filesize < 384 and $execstart and $multiuser and none of ($not_*)
 }

--- a/detection/persistence/suspicious-systemd-unit.sql
+++ b/detection/persistence/suspicious-systemd-unit.sql
@@ -117,7 +117,7 @@ rule systemd_small_multiuser_no_comments_or_documentation : high {
     $not_dbus = "Type=dbus"
     $not_oneshot = "Type=oneshot"
     $not_lima = "Description=lima-guestagent"
-    $not_bluefin = "projectbluefin.io"
+    $not_check_sb = "Description=Service to check for secure boot key enrollment"
   condition:
     filesize < 384 and $execstart and $multiuser and none of ($not_*)
 }
@@ -153,6 +153,7 @@ rule systemd_small_multiuser_not_in_dependency_tree : high {
     $not_idle = "Type=idle"
     $not_systemd = "ExecStart=systemd-"
     $not_lima = "Description=lima-guestagent"
+    $not_check_sb = "Description=Service to check for secure boot key enrollment"
   condition:
     filesize < 384 and $execstart and $multiuser and none of ($not_*)
 }

--- a/detection/persistence/unexpected-active-systemd-units.sql
+++ b/detection/persistence/unexpected-active-systemd-units.sql
@@ -90,6 +90,7 @@ WHERE
         'bluetooth.service,Bluetooth service,',
         'bolt.service,Thunderbolt system service,',
         'bootupd.socket,bootupd.socket,',
+        'brew-upgrade.service,Upgrade Brew packages,1000',
         'brew-update.service,Auto update brew for mutable brew installs,1000',
         'brew-update.timer,Timer for brew update for mutable brew,',
         'brew-upgrade.timer,Timer for brew upgrade for on image brew,',

--- a/detection/persistence/unexpected-active-systemd-units.sql
+++ b/detection/persistence/unexpected-active-systemd-units.sql
@@ -6,7 +6,7 @@
 -- false positives:
 --   * System updates
 --
--- tags: persistent seldom filesystem systemd
+-- tags: persistent seldom filesystem systemd extra
 -- platform: linux
 SELECT --  description AS 'desc',
   fragment_path,


### PR DESCRIPTION
- https-linux: mark it as "extra" so we don't deploy it by default
- DNS: Add wolfi.dev and any terraform provider to the exceptions list
- Hidden executable: add Linuxbrew. We should probably also add `$HOME/.%` in a future PR.
- high disk bytes read: add bin directories to the exceptions list
- systemd: add exceptions for bluefin services, mark unexpected query as extra