### PR TITLE
upgrade osqtool dependency to v1.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ARCH ?= $(shell uname -m)
 COLLECT_DIR ?= "./out/$(shell hostname -s)-$(shell date +%Y-%m-%-d-%H-%M-%S)"
 SUDO ?= "sudo"
-OSQTOOL_VERSION=v1.4.1
+OSQTOOL_VERSION=v1.4.2
 
 out/osqtool-$(ARCH)-$(OSQTOOL_VERSION):
 	mkdir -p out


### PR DESCRIPTION
It fixes the newline munging problem we'd been seeing with `suspicious-systemd-unit`.
