### PR TITLE
fpr: bpftool, curl, pulumi, Docker Desktop, go tests

### DIFF
--- a/detection/c2/unexpected-dns-traffic.sql
+++ b/detection/c2/unexpected-dns-traffic.sql
@@ -68,6 +68,7 @@ WHERE
   )
   -- Some applications hard-code a safe DNS resolver, or allow the user to configure one
   AND s.remote_address NOT IN (
+    '1.0.0.1', -- Cloudflare
     '1.1.1.1', -- Cloudflare
     '1.1.1.2', -- Cloudflare
     '8.8.8.8', -- Google
@@ -92,6 +93,7 @@ WHERE
     '/opt/podman/bin/gvproxy',
     '/System/Volumes/Preboot/Cryptexes/Incoming/OS/System/Library/Frameworks/WebKit.framework/Versions/A/XPCServices/com.apple.WebKit.Networking.xpc/Contents/MacOS/com.apple.WebKit.Networking',
     '/usr/bin/tailscaled',
+    '/sbin/apk',
     '/usr/lib/systemd/systemd-resolved',
     '/usr/sbin/mDNSResponder'
   )

--- a/detection/credentials/unexpected-dev-opener-linux.sql
+++ b/detection/credentials/unexpected-dev-opener-linux.sql
@@ -228,6 +228,7 @@ WHERE
     '/dev/video,obs',
     '/dev/video,obs-ffmpeg-mux',
     '/dev/video,pipewire',
+    '/dev/net/tun,pasta.avx2',
     '/dev/video,signal-desktop',
     '/dev/video,slack',
     '/dev/video,v4l2-relayd',

--- a/detection/evasion/hidden-cwd.sql
+++ b/detection/evasion/hidden-cwd.sql
@@ -143,7 +143,7 @@ WHERE p0.pid IN (
       '~/.hunter/_Base',
       '~/.zsh'
     )
-    OR top_dir IN ('~/Sync')
+    OR top_dir IN ('~/Sync', '~/src', '~/workspace')
     OR dir LIKE '/Library/Apple/System/Library/InstallerSandboxes/.PKInstallSandboxManager-SystemSoftware/%'
     OR dir LIKE '/opt/homebrew/%/.cache/%'
     OR dir LIKE '~/%enterprise-packages/.chainguard'

--- a/detection/evasion/hidden-executable.sql
+++ b/detection/evasion/hidden-executable.sql
@@ -71,6 +71,7 @@ WHERE (
     '~/.pnpm',
     '~/.rbenv',
     '~/.rustup',
+    '~/.pulumi',
     '~/Code',
     '~/code',
     '~/Projects',

--- a/detection/evasion/parent-missing-from-disk-linux.sql
+++ b/detection/evasion/parent-missing-from-disk-linux.sql
@@ -26,6 +26,7 @@ SELECT -- Child
   p0.parent AS p1_pid,
   p1.cgroup_path AS p1_cgroup,
   p1.path AS p1_path,
+  REGEX_MATCH (p1.path, '(.*)/', 1) AS p1_dirname,
   p1.name AS p1_name,
   p1.cmdline AS p1_cmd,
   p1_hash.sha256 AS p1_sha256,
@@ -47,38 +48,14 @@ WHERE
   AND p0.on_disk = 1
   AND NOT p0.pid IN (1, 2)
   AND NOT p1.pid IN (1, 2) -- launchd, kthreadd
-  AND NOT p1.path IN (
-    '/opt/brave.com/brave/brave',
-    '/opt/google/chrome/chrome',
-    '/usr/bin/alacritty',
-    '/usr/bin/roxterm',
-    '/usr/bin/doas',
-    '/usr/bin/dockerd',
-    '/usr/bin/fusermount3',
-    '/usr/libexec/at-spi-bus-launcher',
-    '/usr/bin/gnome-shell',
-    '/usr/bin/ibus-daemon',
-    '/usr/bin/kitty',
-    '/usr/lib/electron22/electron',
-    '/usr/bin/osqueryd',
-    '/usr/bin/make',
-    '/usr/bin/ninja',
-    '/usr/bin/cmake',
-    '/usr/libexec/gvfsd',
-    '/usr/bin/sudo',
-    '/usr/bin/tmux',
-    '/usr/bin/python3',
-    '/usr/bin/yay',
-    '/usr/libexec/gdm-wayland-session',
-    '/usr/libexec/gdm-x-session',
-    '/usr/libexec/gnome-terminal-server',
-    '/usr/lib/gnome-session-binary',
-    '/usr/lib/systemd/systemd',
-    '/usr/lib/xdg-document-portal',
-    '/usr/sbin/auditd',
-    '/usr/sbin/gdm3',
-    '/usr/sbin/sshd',
-    '/usr/share/code/code'
+  -- Probably a software upgrade
+  AND NOT p1_dirname IN (
+    '/usr/lib/electron22',
+    '/usr/bin',
+    '/usr/libexec',
+    '/usr/lib/systemd',
+    '/usr/lib',
+    '/usr/share/code'
   ) -- long-running launchers
   AND NOT p1.name IN (
     'bash',
@@ -91,11 +68,12 @@ WHERE
     'gnome-shell',
     'kubelet',
     'kube-proxy',
+    'Docker Desktop',
     'lightdm',
     'nvim',
     'sh',
     'slack'
-  ) -- These alerts were unfortunately useless - lots of spam on macOS
+  )
   AND NOT (
     p1.path LIKE '/app/%'
     AND p1.cgroup_path LIKE '/user.slice/user-1000.slice/user@1000.service/app.slice/%'

--- a/detection/evasion/unusual-executable-name-macos.sql
+++ b/detection/evasion/unusual-executable-name-macos.sql
@@ -93,6 +93,7 @@ WHERE
     'at.obdev.littlesnitch.networkextension',
     'com.microsoft.teams2.notificationcenter',
     'cpu',
+    'test',
     'dynamiclinkmanager',
     'EcammLiveVideoOutAssistantXPCHelper',
     'launchd_startx',
@@ -104,6 +105,7 @@ WHERE
   AND NOT pname LIKE 'cody-engine-%'
   AND NOT pname LIKE '__%go_build_%'
   AND NOT pname LIKE '__%go_test_%'
+  AND NOT pname LIKE '__Test%'
   -- example: 85C27NK92C.com.flexibits.fantastical2.mac.helper
   AND NOT pname LIKE "%.com.flexibits.fantastical2.mac.helper"
   AND NOT s.authority = "Software Signing"

--- a/detection/execution/sketchy-fetcher-events.sql
+++ b/detection/execution/sketchy-fetcher-events.sql
@@ -172,6 +172,17 @@ WHERE
     AND pe.cmdline NOT LIKE '%-o%'
     AND pe.cmdline NOT LIKE '%-O%'
   )
+  AND NOT (
+    pe.euid > 500
+    -- /usr/bin/curl https://34.117.0.114:443 -k
+    AND REGEX_MATCH(pe.cmdline, '(curl https://[\w\.\:\/]+ -k)$', 1) != ""
+  )
+  AND NOT (
+    pe.euid > 500
+    -- /usr/bin/curl -k https://34.117.0.114:443
+    AND REGEX_MATCH(pe.cmdline, '(curl -k https://[\w\.\:\/]+)$', 1) != ""
+  )
+
   -- These are typically curl -k calls
   -- We need the addr "IS NOT NULL" to avoid filtering out
   -- NULL entries

--- a/detection/execution/tiny-executable-events.sql
+++ b/detection/execution/tiny-executable-events.sql
@@ -43,8 +43,9 @@ WHERE
   AND p.path NOT LIKE '%.rb'
   AND p.path NOT IN (
     '/sbin/ldconfig',
-    '/usr/sbin/ldconfig',
     '/usr/bin/c_rehash',
+    '/usr/sbin/bpftool',
+    '/usr/sbin/ldconfig',
     '/usr/sbin/update-ca-certificates'
   )
   AND NOT p.path LIKE '%/bin/firefox'
@@ -59,9 +60,4 @@ WHERE
   AND NOT (
     p.path = "/"
     AND file.size < 8192
-  )
-  AND NOT p.cmdline IN (
-    'bpftool --version',
-    'bpftool --help',
-    'bpftool -V'
   )


### PR DESCRIPTION
This changes `parent-missing-from-disk-linux.sql` to have a more generalized class of exceptions based on directories, to avoid whack-a-mole from system upgrades.