### PR TITLE
Add exceptions for Arc, busybox, and Edge; fix existing exceptions

### DIFF
--- a/detection/c2/unexpected-https-macos.sql
+++ b/detection/c2/unexpected-https-macos.sql
@@ -110,6 +110,7 @@ WHERE
     '0,licenseDaemon,licenseDaemon,Developer ID Application: PACE Anti-Piracy, Inc. (TFZ8226T6X),com.paceap.eden.licenseDaemon',
     '0,chainctl,chainctl,,a.out',
     '500,agent,agent,Developer ID Application: Datadog, Inc. (JKFCB4CN7C),agent',
+    '500,Arc Helper,Arc Helper,Developer ID Application: The Browser Company of New York Inc. (S6N382Y83G),company.thebrowser.browser.helper',
     '500,Authy,Authy,Apple iPhone OS Application Signing,com.authy',
     '500,podman,podman,Developer ID Application: Red Hat, Inc. (HYSCB8KRL2),podman',
     '500,bash,bash,,bash',

--- a/detection/credentials/unexpected-dev-opener-linux.sql
+++ b/detection/credentials/unexpected-dev-opener-linux.sql
@@ -171,6 +171,7 @@ WHERE
   AND NOT path_exception IN (
     '/dev/autofs,systemd',
     '/dev/console,agetty',
+    '/dev/console,busybox',
     '/dev/cpu/0/msr,nvidia-powerd',
     '/dev/drm_dp_aux,fwupd',
     '/dev/fb,Xorg',

--- a/detection/evasion/hidden-executable.sql
+++ b/detection/evasion/hidden-executable.sql
@@ -116,6 +116,7 @@ WHERE (
   AND NOT dir LIKE '%/.terraform/providers/%'
   AND NOT dir LIKE '%/node_modulues/.bin/hugo'
   AND NOT dir LIKE '%/node_modules/.pnpm/%'
+  AND NOT dir LIKE '%/.Trash/1Password %.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS'
   AND NOT f.directory LIKE '/Applications/Corsair iCUE5 Software/.cuepkg-%'
   AND NOT f.directory LIKE '%/Applications/PSI Bridge Secure Browser.app/Contents/Resources/.apps/darwin/%'
   AND NOT f.directory LIKE '/var/home/linuxbrew/.linuxbrew/Cellar/%'
@@ -125,6 +126,5 @@ WHERE (
     AND p0.name LIKE '%-wrappe%'
   )
   AND NOT f.path LIKE '%/.Trash/1Password %.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS'
-  AND NOT f.path LIKE '/private/var/root/.Trash/OneDrive %.app/Contents/StandaloneUpdater.app/Contents/MacOS'
   AND NOT f.path LIKE '/home/%/.local/share/AppImage/ZenBrowser.AppImage'
 GROUP BY f.path

--- a/detection/evasion/unexpected-dev-entries.sql
+++ b/detection/evasion/unexpected-dev-entries.sql
@@ -45,6 +45,7 @@ WHERE
       OR file.path LIKE '/dev/shm/u1000-Valve%'
       OR file.path LIKE '/dev/shm/aomshm.%'
       OR file.path LIKE '/dev/shm/jack_db%'
+      OR file.path LIKE '/dev/shm/.com.microsoft.Edge.*'
     )
   )
   AND NOT (

--- a/detection/persistence/unexpected-device-linux.sql
+++ b/detection/persistence/unexpected-device-linux.sql
@@ -193,6 +193,7 @@ WHERE (
     '/dev/sg,character',
     '/dev/sgx_provision',
     '/dev/shm/,directory',
+    '/dev/shm/envoy_shared_memory_,regular',
     '/dev/shm/libpod_lock,regular',
     '/dev/shm/libpod_rootless_lock_,regular',
     '/dev/shm/lttng-ust-wait-,regular',

--- a/detection/persistence/unexpected-listening-port-macos.sql
+++ b/detection/persistence/unexpected-listening-port-macos.sql
@@ -272,7 +272,7 @@ WHERE port != 0
   AND NOT (
     (
       exception_key LIKE '80,6,500,ssh,Software Signing'
-      AND p.cmdline LIKE '%/.colima/_lima/colima-docker/ssh.sock'
+      AND p.cmdline LIKE '%/.colima/_lima/colima-docker/ssh.sock%'
     )
   )
 GROUP BY exception_key


### PR DESCRIPTION
This PR adds additional exceptions for the Arc browser, busybox, Edge, and Envoy and fixes two exceptions from #413.