### PR TITLE
Address noisy alerts (https-macos, hidden exec, bytes written, dev entries, long running)

### DIFF
--- a/detection/c2/unexpected-https-macos.sql
+++ b/detection/c2/unexpected-https-macos.sql
@@ -3,7 +3,7 @@
 -- references:
 --   * https://attack.mitre.org/techniques/T1071/ (C&C, Application Layer Protocol)
 --
--- tags: transient state net often
+-- tags: transient state net often extra
 -- platform: macos
 SELECT
   pos.protocol,
@@ -213,18 +213,17 @@ WHERE
   )
   AND NOT s.authority IN (
     'Developer ID Application: Adguard Software Limited (TC3Q7MAJXF)',
-    'Developer ID Application: AMZN Mobile LLC (94KV3E626L)',
-    'Developer ID Application: Autodesk (XXKJ396S2Y)',
     'Developer ID Application: Adobe Inc. (JQ525L2MZD)',
     'Developer ID Application: AgileBits Inc. (2BUA8C4S2C)',
+    'Developer ID Application: AMZN Mobile LLC (94KV3E626L)',
     'Developer ID Application: ANCHORE, INC. (9MJHKYX5AT)',
+    'Developer ID Application: Autodesk (XXKJ396S2Y)',
     'Developer ID Application: Bitdefender SRL (GUNFMW623Y)',
     'Developer ID Application: Brave Software, Inc. (KL8N8XSYF4)',
     'Developer ID Application: Canonical Group Limited (X4QN7LTP59)',
     'Developer ID Application: Corsair Memory, Inc. (Y93VXCB8Q5)',
     'Developer ID Application: Denver Technologies, Inc (2BBY89MBSN)',
     'Developer ID Application: Docker Inc (9BNSXJN65R)',
-    'Developer ID Application: TechSmith Corporation (7TQL462TU8)',
     'Developer ID Application: Ecamm Network, LLC (5EJH68M642)',
     'Developer ID Application: Elasticsearch, Inc (2BT3HPN62Z)',
     'Developer ID Application: Farhan Ahmed (4RZN52RN5P)',
@@ -248,7 +247,9 @@ WHERE
     'Developer ID Application: SteelSeries (6WGL6CHFH2)',
     'Developer ID Application: Sublime HQ Pty Ltd (Z6D26JE4Y4)',
     'Developer ID Application: Tailscale Inc. (W5364U7YZB)',
+    'Developer ID Application: TechSmith Corporation (7TQL462TU8)',
     'Developer ID Application: Tenable, Inc. (4B8J598M7U)',
+    'Developer ID Application: The Browser Company of New York Inc. (S6N382Y83G)',
     'Developer ID Application: Valve Corporation (MXGJJ98X76)',
     'Developer ID Application: Zoom Video Communications, Inc. (BJ4HAAB9B3)',
     'Developer ID Application: Zwift, Inc (C2GM8Y9VFM)'

--- a/detection/collection/high-disk-bytes-written.sql
+++ b/detection/collection/high-disk-bytes-written.sql
@@ -10,7 +10,7 @@
 -- references:
 --   * https://attack.mitre.org/tactics/TA0009/ (Collection)
 --
--- tags: transient process
+-- tags: transient process extra
 SELECT
   -- WARNING: Writes to tmpfs are not reflected against this counter
   p0.disk_bytes_written AS bytes_written,
@@ -206,6 +206,7 @@ WHERE
   )
   AND p0.path NOT LIKE '/Applications/%.app/Contents/%'
   AND p0.path NOT LIKE '/home/%/.local/share/Steam'
+  AND p0.path NOT LIKE '/Library/Application Support/%'
   AND p0.path NOT LIKE '/nix/store/%/bin/nix'
   AND p0.path NOT LIKE '/nix/store/%/bin/%sh'
   AND p0.path NOT LIKE '/nix/store/%kolide-launcher-%/bin/launcher'

--- a/detection/evasion/hidden-executable.sql
+++ b/detection/evasion/hidden-executable.sql
@@ -8,7 +8,6 @@
 SELECT f.directory,
   f.btime,
   p0.start_time,
-  REPLACE(f.directory, u.directory, '~') AS dir,
   RTRIM(
     COALESCE(
       REGEX_MATCH (
@@ -28,6 +27,8 @@ SELECT f.directory,
     ),
     REPLACE(f.directory, u.directory, '~')
   ) AS top3_dir,
+  REPLACE(f.directory, u.directory, '~') AS homedir,
+  REPLACE(f.path, u.directory, '~') AS homepath,
   -- Child
   p0.pid AS p0_pid,
   p0.path AS p0_path,
@@ -63,6 +64,13 @@ WHERE (
     OR f.filename LIKE '.%'
     OR f.directory LIKE '%/.%'
   )
+  AND NOT homedir LIKE '~/.%/bin'
+  AND NOT homedir LIKE '~/%/node_modules/.bin'
+  AND NOT homedir LIKE '~/.%/%x64/%'
+  AND NOT homedir LIKE '%/node_modulues/.%'
+  AND NOT homepath LIKE '~/%arm64%'
+  AND NOT homepath LIKE '~/%x86_64%'
+  AND NOT top3_dir LIKE '~/.%/extensions'
   AND NOT top2_dir IN (
     '~/.dropbox-dist',
     '~/.goenv',
@@ -85,38 +93,24 @@ WHERE (
     '~/.krew'
   )
   AND NOT top3_dir IN (
-    '~/.arkade/bin',
     '~/.bin',
     '~/.bin-unwrapped',
     '~/.cache/gitstatus',
-    '~/.cache/selenium/chromedriver/~',
-    '~/.cargo/bin',
+    '~/.cache/selenium',
     '~/.config/bluejeans-v2',
     '~/.config/Code',
     '~/.config/nvm',
-    '~/.deno/bin',
     '~/.devpod/contexts',
     '~/.docker/cli-plugins',
     '~/.dotfiles/.local',
-    '~/.fig/bin',
-    '~/.go/bin',
     '/home/linuxbrew/.linuxbrew',
-    '~/.linkerd2/bin',
     '~/.linuxbrew/Cellar',
     '~/node_modules/.bin',
     '~/.nvm/versions',
-    '~/.provisio/bin',
     '~/.pyenv/versions',
     '~/.steampipe/db',
-    '~/thinkorswim/.install4j',
-    '~/.vscode/extensions',
-    '~/.vscode-insiders/extensions'
+    '~/thinkorswim/.install4j'
   )
-  AND NOT dir LIKE '~/Library/Application Support/Code/User/globalStorage/ms-dotnettools.vscode-dotnet-runtime/.dotnet/%'
-  AND NOT dir LIKE '%/.terraform/providers/%'
-  AND NOT dir LIKE '%/node_modulues/.bin/hugo'
-  AND NOT dir LIKE '%/node_modules/.pnpm/%'
-  AND NOT dir LIKE '%/.Trash/1Password %.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS'
   AND NOT f.directory LIKE '/Applications/Corsair iCUE5 Software/.cuepkg-%'
   AND NOT f.directory LIKE '%/Applications/PSI Bridge Secure Browser.app/Contents/Resources/.apps/darwin/%'
   AND NOT f.directory LIKE '/var/home/linuxbrew/.linuxbrew/Cellar/%'
@@ -125,6 +119,8 @@ WHERE (
     f.path LIKE '/nix/store/%'
     AND p0.name LIKE '%-wrappe%'
   )
-  AND NOT f.path LIKE '%/.Trash/1Password %.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS'
-  AND NOT f.path LIKE '/home/%/.local/share/AppImage/ZenBrowser.AppImage'
+  AND NOT homedir LIKE '~/.Trash/1Password %.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS'
+  AND NOT homedir LIKE '~/.local/share/AppImage/ZenBrowser.AppImage'
+  AND NOT homedir LIKE '~/Library/Application Support/Code/User/globalStorage/ms-dotnettools.vscode-dotnet-runtime/.dotnet/%'
+  AND NOT homedir LIKE '%/.Trash/1Password %.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS'
 GROUP BY f.path

--- a/detection/evasion/unexpected-dev-entries.sql
+++ b/detection/evasion/unexpected-dev-entries.sql
@@ -45,7 +45,7 @@ WHERE
       OR file.path LIKE '/dev/shm/u1000-Valve%'
       OR file.path LIKE '/dev/shm/aomshm.%'
       OR file.path LIKE '/dev/shm/jack_db%'
-      OR file.path LIKE '/dev/shm/.com.microsoft.Edge.*'
+      OR file.path LIKE '/dev/shm/.com.microsoft.Edge.%'
     )
   )
   AND NOT (

--- a/detection/evasion/unexpected-process-extension-linux.sql
+++ b/detection/evasion/unexpected-process-extension-linux.sql
@@ -72,6 +72,10 @@ WHERE
     '28',
     '29',
     '30',
+    '31',
+    '32',
+    '33',
+    '34',
     'backend',
     'emacs',
     'build',
@@ -85,6 +89,7 @@ WHERE
   )
   AND NOT basename LIKE 'python3.%'
   AND NOT basename LIKE 'python2.%'
+  AND NOT basename LIKE 'kubectl-%'
   AND NOT basename LIKE 'terraform-provider%'
   AND NOT basename LIKE 'ld-%.so'
   AND NOT basename LIKE 'unison-%'

--- a/detection/execution/unexpected-long-running-security-framework-macos.sql
+++ b/detection/execution/unexpected-long-running-security-framework-macos.sql
@@ -61,6 +61,7 @@ WHERE -- Focus on longer-running programs
       AND NOT path LIKE '/Users/%/dev/%'
       AND NOT path LIKE '/Users/%/src/%'
       AND NOT path LIKE '/Users/%/bin/%'
+      AND NOT path LIKE '/nix/store/%'
       AND NOT path LIKE '/Users/%/Library/Application Support/com.elgato.StreamDeck/Plugins/%'
       AND NOT path LIKE '/Users/%/Library/Application Support/Zed/supermaven/%'
       AND NOT path LIKE '/private/var/folders%/T/go-build%/exe/%'


### PR DESCRIPTION
- unexpected-https-macos: add extra tag
- high-disk-bytes-written: add extra tag
- hidden executable: add more generic patterns to decrease whack-a-mole
- unexpected dev entries: fix edge bug
- long running framework: add nix exception
- recently created, long running: refactor