### PR TITLE
suspicious systemd: accept any char instead of single quote

### DIFF
--- a/detection/persistence/suspicious-systemd-unit.sql
+++ b/detection/persistence/suspicious-systemd-unit.sql
@@ -226,7 +226,7 @@ rule usr_bin_execstop_shell : medium {
     $execstop = /ExecStop=\/bin\/sh .{0,64}/
     $not_podman_logging = "/usr/bin/podman $LOGGING"
     $not_stderr = /ExecStop=\/bin\/sh .{0,64}set -eu/
-    $not_nfs = /ExecStop=\/bin\/sh -c \'\/usr\/sbin\/nfsdctl /
+    $not_nfs = /ExecStop=\/bin\/sh -c .\/usr\/sbin\/nfsdctl /
   condition:
     filesize < 4096 and $execstop and none of ($not*)
 }


### PR DESCRIPTION
Cheap workaround for Kolide error:

`Queries sql is invalid. [1:354] Syntax error found near Single-quoted String Literal (WHERE Clause)`

we should accept any sort of quote here anyways.
