### PR TITLE
Add Zoom to the launchd list

### DIFF
--- a/detection/persistence/unexpected-launchd-program-arguments.sql
+++ b/detection/persistence/unexpected-launchd-program-arguments.sql
@@ -76,6 +76,7 @@ WHERE
     'Developer ID Application: Tenable, Inc. (4B8J598M7U)',
     'Developer ID Application: Ubiquiti Inc. (4P645293E8)',
     'Developer ID Application: X-Rite, Incorporated (2K7GT73B4R)',
+    'Developer ID Application: Zoom Video Communications, Inc. (BJ4HAAB9B3)',
     'Software Signing', -- Apple
     'yabai-cert'
   )


### PR DESCRIPTION
# Problem
I recently added Zoom to my machine, and this alert fired. We've seen it a couple times elsewhere as well.

# Fix
Add the Zoom program authority to the list.

```bash
codesign -d -vvv /Applications/zoom.us.app
Executable=/Applications/zoom.us.app/Contents/MacOS/zoom.us
Identifier=us.zoom.xos
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20500 size=919 flags=0x10000(runtime) hashes=18+7 location=embedded
Hash type=sha256 size=32
CandidateCDHash sha256=345752c25f118b0f729c16a43b88008702d5b636
CandidateCDHashFull sha256=345752c25f118b0f729c16a43b88008702d5b6363dce1b6f188d183df65ba74c
Hash choices=sha256
CMSDigest=345752c25f118b0f729c16a43b88008702d5b6363dce1b6f188d183df65ba74c
CMSDigestType=2
CDHash=345752c25f118b0f729c16a43b88008702d5b636
Signature size=9032
**Authority=Developer ID Application: Zoom Video Communications, Inc. (BJ4HAAB9B3)**
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=Dec 23, 2024 at 1:35:54 AM
Info.plist entries=36
TeamIdentifier=BJ4HAAB9B3
Runtime Version=14.2.0
Sealed Resources version=2 rules=13 files=213
Internal requirements count=1 size=172
```