### PR TITLE
makefile: update sql reformat to use in-place --fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ out/packs.zip: packs out/osquery.conf
 
 .PHONY: reformat
 reformat:
-	find . -type f -name "*.sql" | perl -ne 'chomp; system("cp $$_ /tmp/fix.sql && npx sql-formatter -l sqlite /tmp/fix.sql > $$_");'
+	find . -type f -name "*.sql" -exec npx sql-formatter -l sqlite --fix {} \;
 
 .PHONY: reformat-updates
 reformat-updates:
-	git status -s | awk '{ print $$2 }' | grep ".sql" | perl -ne 'chomp; print("$$_\n"); system("cp $$_ /tmp/fix.sql && npx sql-formatter -l sqlite /tmp/fix.sql > $$_");'
+	git status -s | awk '{ print $$2 }' | grep ".sql" | xargs -n1 npx sql-formatter -l sqlite --fix
 
 .PHONY: detect
 detect: ./out/osqtool-$(ARCH)-$(OSQTOOL_VERSION)
@@ -79,4 +79,3 @@ verify: ./out/osqtool-$(ARCH)-$(OSQTOOL_VERSION)
 	$(SUDO) ./out/osqtool-$(ARCH)-$(OSQTOOL_VERSION) --workers 1 --max-results=0 --max-query-duration=16s --max-total-daily-duration=2h30m --max-query-daily-duration=1h verify detection
 
 all: out/packs.zip
-


### PR DESCRIPTION
If 'npm' wasn't installed, the existing Makefile rules would accidentally overwrite your SQL files. That's not cool.

